### PR TITLE
Add login page with redirect to lot reservation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
-# Proyecto de Registro Habitare\n\nFormulario básico en PHP que guarda nombre, email y contraseña (encriptada) en MySQL. Desplegado automáticamente a Bluehost con GitHub Actions.
+# Proyecto de Registro Habitare
+
+Formulario básico en PHP que guarda nombre, email y contraseña (encriptada) en MySQL. Desplegado automáticamente a Bluehost con GitHub Actions.

--- a/login.php
+++ b/login.php
@@ -1,0 +1,44 @@
+<?php
+session_start();
+require 'db.php';
+
+if ($_SERVER["REQUEST_METHOD"] === "POST") {
+    $mail = $_POST['mail'];
+    $contrasena = $_POST['contrasena'];
+
+    $stmt = $conn->prepare("SELECT contrasena FROM usuarios WHERE mail = ?");
+    $stmt->bind_param("s", $mail);
+    $stmt->execute();
+    $result = $stmt->get_result();
+    if ($row = $result->fetch_assoc()) {
+        if (password_verify($contrasena, $row['contrasena'])) {
+            $_SESSION['user'] = $mail;
+            header('Location: reserva.php');
+            exit;
+        } else {
+            $error = 'Contraseña incorrecta.';
+        }
+    } else {
+        $error = 'Usuario no encontrado.';
+    }
+}
+?>
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <title>Login</title>
+</head>
+<body>
+    <h2>Ingresar</h2>
+    <?php if(!empty($error)) echo '<p>' . $error . '</p>'; ?>
+    <form method="POST" action="login.php">
+        <label>Email:</label><br>
+        <input type="email" name="mail" required><br><br>
+        <label>Contraseña:</label><br>
+        <input type="password" name="contrasena" required><br><br>
+        <button type="submit">Login</button>
+        <a href="index.php"><button type="button">Registrarse</button></a>
+    </form>
+</body>
+</html>

--- a/reserva.php
+++ b/reserva.php
@@ -1,0 +1,18 @@
+<?php
+session_start();
+if (!isset($_SESSION['user'])) {
+    header('Location: login.php');
+    exit;
+}
+?>
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <title>Reserva de Lotes</title>
+</head>
+<body>
+    <h2>Reserva de Lotes</h2>
+    <p>Página en construcción.</p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- reformat README newlines
- add `login.php` with login form and link to the existing registration page
- add `reserva.php` placeholder for future lot reservation area

## Testing
- `php -l login.php` *(fails: `php` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68589e0802e083299322914430d61071